### PR TITLE
Switch default filter to Grism1

### DIFF
--- a/py/psf_grid_utils.py
+++ b/py/psf_grid_utils.py
@@ -15,6 +15,17 @@ if psf_grid_data_read is None:
 wfi = stpsf.WFI()
 wfi.filter = "GRISM1"
 
+def switch_filter(filter_name):
+    """
+    Switched to the given filter
+    """
+
+    wfi.filter = filter_name
+
+    print(wfi.filter)
+    
+    return 0 
+
 def load_psf_grid(grid_file, psf_grid_data_read=psf_grid_data_read):
     """
     Reads in a saved GriddedPSFModel fits file. Returns that file.

--- a/py/psf_grid_utils.py
+++ b/py/psf_grid_utils.py
@@ -53,8 +53,13 @@ def save_one_grid(det_num, wavelength, outdir, fov_pixels=364, overwrite=False, 
 
     print(f"\nGenerating PSF Grid fits file for SCA{det_num:02} at {wavelength:.0f}\u212b...")
     create_grid_one_detector(det_num, wavelength, fov_pixels=fov_pixels, save=True, outdir=outdir, overwrite=overwrite, **kwargs)
-    
-    filename = f"{wfi.name}_{wfi.filter}_fovp{fov_pixels}_wave{wavelength:.0f}_SCA{det_num:02}.fits".lower()
+
+    if wfi.filter == "GRISM1":
+        filename = f"{wfi.name}_{wfi.filter}_fovp{fov_pixels}_wave{wavelength:.0f}_SCA{det_num:02}.fits".lower()
+    elif wfi.filter == "GRISM1":
+        filename = f"{wfi.name}_{wfi.filter}_fovp{fov_pixels}_wave{wavelength:.0f}_wfi{det_num:02}.fits".lower()
+    else:
+        raise ValueError(f"Unexpected filter: {wfi.filter}")
     filepath = os.path.join(outdir, filename)
 
     print(f"Adding version info to header for SCA{det_num:02} at {wavelength:.0f}\u212b...")

--- a/py/psf_grid_utils.py
+++ b/py/psf_grid_utils.py
@@ -13,7 +13,7 @@ if psf_grid_data_read is None:
     print('psf_grid_data_read environment variable has not been set')
 
 wfi = stpsf.WFI()
-wfi.filter = "GRISM0"
+wfi.filter = "GRISM1"
 
 def load_psf_grid(grid_file, psf_grid_data_read=psf_grid_data_read):
     """
@@ -31,7 +31,7 @@ def save_one_grid(det_num, wavelength, outdir, fov_pixels=364, overwrite=False, 
 
     Follows naming scheme: 
     {instrument}_{filter}_{fovp}_wave{wavelength}_{det}.fits
-    e.g. wfi_grism0_fovp364_wave10000_sca01.fits
+    e.g. wfi_grism1_fovp364_wave10000_sca01.fits
     """
     
     __KWARGS_USED = False
@@ -58,7 +58,7 @@ def create_grid_one_detector(det_num, wavelength, fov_pixels=364, save=False, ou
 
     Follows naming scheme: 
     {instrument}_{filter}_{fovp}_wave{wavelength}_{det}.fits
-    e.g. wfi_grism0_fovp364_wave10000_sca01.fits
+    e.g. wfi_grism1_fovp364_wave10000_sca01.fits
     """
 
     detector = "SCA{:02}".format(det_num)

--- a/py/psf_grid_utils.py
+++ b/py/psf_grid_utils.py
@@ -54,7 +54,7 @@ def save_one_grid(det_num, wavelength, outdir, fov_pixels=364, overwrite=False, 
     print(f"\nGenerating PSF Grid fits file for SCA{det_num:02} at {wavelength:.0f}\u212b...")
     create_grid_one_detector(det_num, wavelength, fov_pixels=fov_pixels, save=True, outdir=outdir, overwrite=overwrite, **kwargs)
 
-    if wfi.filter == "GRISM1":
+    if wfi.filter == "GRISM0":
         filename = f"{wfi.name}_{wfi.filter}_fovp{fov_pixels}_wave{wavelength:.0f}_SCA{det_num:02}.fits".lower()
     elif wfi.filter == "GRISM1":
         filename = f"{wfi.name}_{wfi.filter}_fovp{fov_pixels}_wave{wavelength:.0f}_wfi{det_num:02}.fits".lower()

--- a/scripts/mk_all_grids.py
+++ b/scripts/mk_all_grids.py
@@ -4,24 +4,30 @@ import numpy as np
 import psf_grid_utils as pgu
 from multiprocessing import Pool
 
+# get PSF Grid write directory
 outdir = os.getenv("psf_grid_data_write")
 if outdir is None:
     raise RuntimeError("psf_grid_data_write environment variable has not been set")
 
+# get github directory 
 github_dir = os.getenv("github_dir")
 if github_dir is None:
     raise RuntimeError("github_dir environment variable has not been set")
 
+# get psf_grid defaults
 conf_file = os.path.join(github_dir, "psf_grids/data/psf_grid_config.yaml")
 with open(conf_file) as f:
     grid_conf = yaml.safe_load(f)
 
+# get grizli config defaults
 conf_file = os.path.join(github_dir, "grism_sim/data/grizli_config.yaml")
 with open(conf_file) as f:
     grizli_conf = yaml.safe_load(f)
 
+# set wavelength bins
 bins = np.linspace(grizli_conf["minlam"], grizli_conf["maxlam"], grizli_conf["npsfs"] + 1)
 
+# match every detector with every wavelength bin
 params = []
 for det_num in range(1, 19):
      for wave in bins[:-1]:
@@ -32,9 +38,15 @@ def mk_grid(args):
 
 if __name__=="__main__":
     nproc = 90
-    with Pool(processes=nproc) as pool:
-        res = pool.map(mk_grid, params)
 
-    if np.any(res):
-        print("Unexpected result. Potential failure")
-        print(res)
+    # create files for both filters in sequence
+    for filter in ["GRISM0", "GRISM1"]:
+        pgu.switch_filter(filter)
+        
+        # create all psf grids for a given filter in parallel
+        with Pool(processes=nproc) as pool:
+            res = pool.map(mk_grid, params)
+
+        if np.any(res):
+            print("Unexpected result. Potential failure")
+            print(res)

--- a/scripts/psf_job_script.sh
+++ b/scripts/psf_job_script.sh
@@ -7,7 +7,7 @@
 #SBATCH --mail-user=keith.buckholz@yale.edu
 #SBATCH --mail-type=ALL
 #SBATCH -A m4943
-#SBATCH -t 0:45:0
+#SBATCH -t 1:30:0
 #SBATCH -L cfs
 
 srun python /global/common/software/m4943/grizli0/psf_grids/scripts/mk_all_grids.py


### PR DESCRIPTION
Switch default filter to GRISM1. Write filter switching function to run any filter. Update psf_grid building script to generate grids for both GRISM0 & GRISM1 filter. 

Note: grids are generated in two sequential batches. This is because I worry that changing the filter while running multiple parallel psf_grid simulations may have unintended effects. Intead, the filter is fixed while a batch of simulations are run in parallel; then the filter is changed and a new bath of simulations are run in parallel.